### PR TITLE
Remove polyfill.io script from MathJax setup

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -13,7 +13,6 @@
     options: { skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'] }
   };
 </script>
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 {% endif %}
 


### PR DESCRIPTION
polyfill.io was sold and now serves malware (supply-chain risk); browsers and security tools warn/block it on every page load. MathJax 3 doesn't need it on modern browsers, so drop the line — math still renders.