### PR TITLE
Set up English/Korean mirror structure

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,9 +18,9 @@ minimal_mistakes_skin    : "air" # "air", "aqua", "contrast", "dark", "dirt", "n
 locale                   : "ko_KR"
 title                    : "Starwise Tech Blog"
 title_separator          : "-"
-subtitle                 : "AI · 음성 인식 · 온디바이스" # site tagline that appears below site title in masthead
+subtitle                 : "Machine learning, engineering, and everything in between" # site tagline that appears below site title in masthead
 name                     : "GT-KIM"
-description              : "AI와 음성 인식, 온디바이스 머신러닝을 다루는 기술 블로그. 논문 리뷰와 한국어 ASR 리더보드 프로젝트(OpenKoASR)를 기록합니다."
+description              : "A tech blog by Gwantae Kim on machine learning, software engineering, and research — deep dives, paper notes, and side projects."
 url                      : "https://GT-KIM.github.io" # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
 baseurl                  : # the subpath of your site, e.g. "/blog"
 repository               : "GT-KIM/GT-KIM.github.io" # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
@@ -190,14 +190,11 @@ sass:
 
 # Outputting
 permalink: /:categories/:title/
-paginate: 5 # amount of posts to show
-paginate_path: /page:num/
 timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 
 # Plugins (previously gems:)
 plugins:
-  - jekyll-paginate
   - jekyll-sitemap
   - jekyll-gist
   - jekyll-feed
@@ -205,7 +202,6 @@ plugins:
 
 # mimic GitHub Pages with --safe
 whitelist:
-  - jekyll-paginate
   - jekyll-sitemap
   - jekyll-gist
   - jekyll-feed
@@ -262,5 +258,6 @@ defaults:
       comments: # true
       share: true
       related: true
+      lang: en # default language; Korean posts override with `lang: ko`
       sidebar:
        nav: "sidebar-category"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,16 +1,10 @@
 # main links
 main:
-  - title: "Home"
-    url: "https://gt-kim.github.io/"
-  # - title: "About"
-  #   url: https://mmistakes.github.io/minimal-mistakes/about/
-  # - title: "Sample Posts"
-  #   url: /year-archive/
-  # - title: "Sample Collections"
-  #   url: /collection-archive/
-  # - title: "Sitemap"
-  #   url: /sitemap/
-  
+  - title: "English"
+    url: "/"
+  - title: "한국어"
+    url: "/ko/"
+
 sidebar-category:
  - title: "Category"
    children:

--- a/_includes/lang-switch.html
+++ b/_includes/lang-switch.html
@@ -1,0 +1,17 @@
+{% comment %}
+  Language switcher: shows a link to the mirror post in the other language.
+  A post opts in by setting a shared `ref:` key and its `lang:` (en|ko).
+  Renders nothing until a counterpart with the same `ref` exists.
+{% endcomment %}
+{% if page.ref %}
+  {% assign mirror = site.posts | where: "ref", page.ref | where_exp: "p", "p.lang != page.lang" | first %}
+  {% if mirror %}
+    <p class="page__lang-switch notice--info" style="display:inline-block;padding:.4em .8em;">
+      {% if page.lang == "ko" %}
+        🇺🇸 <a href="{{ mirror.url | relative_url }}">Read this in English</a>
+      {% else %}
+        🇰🇷 <a href="{{ mirror.url | relative_url }}">한국어로 읽기</a>
+      {% endif %}
+    </p>
+  {% endif %}
+{% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,19 +4,18 @@ layout: archive
 
 {{ content }}
 
-<h3 class="archive__subtitle">{{ site.data.ui-text[site.locale].recent_posts | default: "Recent Posts" }}</h3>
+<h3 class="archive__subtitle">Recent Posts</h3>
 
-{% if paginator %}
-  {% assign posts = paginator.posts %}
-{% else %}
-  {% assign posts = site.posts %}
-{% endif %}
-
+{% comment %} Home is the English landing — show English posts only. Korean posts live under /ko/. {% endcomment %}
+{% assign en_posts = site.posts | where: "lang", "en" %}
 {% assign entries_layout = page.entries_layout | default: 'list' %}
+
+{% if en_posts.size > 0 %}
 <div class="entries-{{ entries_layout }}">
-  {% for post in posts %}
+  {% for post in en_posts %}
     {% include archive-single.html type=entries_layout %}
   {% endfor %}
 </div>
-
-{% include paginator.html %}
+{% else %}
+<p><em>No English posts yet — they're on the way. In the meantime, browse the <a href="{{ '/ko/' | relative_url }}">한국어 글 →</a></em></p>
+{% endif %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -37,6 +37,8 @@ layout: default
         </header>
       {% endunless %}
 
+      {% include lang-switch.html %}
+
       <section class="page__content e-content" itemprop="text">
         {% if page.toc %}
           <aside class="sidebar__right {% if page.toc_sticky %}sticky{% endif %}">

--- a/_pages/ko.md
+++ b/_pages/ko.md
@@ -1,0 +1,16 @@
+---
+title: "한국어 글"
+layout: archive
+permalink: /ko/
+author_profile: true
+sidebar:
+    nav: "sidebar-category"
+---
+
+한국어로 작성한 글 모음입니다. 영어 글은 상단 **English** 탭에서 볼 수 있습니다.
+
+{% assign ko_posts = site.posts | where: "lang", "ko" %}
+<div class="entries-list">
+{% for post in ko_posts %}{% include archive-single.html type="list" %}{% endfor %}
+</div>
+{% if ko_posts.size == 0 %}_아직 글이 없습니다._{% endif %}

--- a/_posts/AI_review/2024-02-13-Unsupervised real-world super resolution with cycle generative adversarial network and domain discriminator.md
+++ b/_posts/AI_review/2024-02-13-Unsupervised real-world super resolution with cycle generative adversarial network and domain discriminator.md
@@ -1,4 +1,5 @@
 ---
+lang: ko
 title: "Unsupervised real-world super resolution with cycle generative adversarial network and domain discriminator"
 categories:
  - ai_review

--- a/_posts/Korean_ASR/2026-06-02-rtfx-ondevice-korean-asr.md
+++ b/_posts/Korean_ASR/2026-06-02-rtfx-ondevice-korean-asr.md
@@ -1,4 +1,5 @@
 ---
+lang: ko
 title: "정확도만 높이면 될까 — RTFx와 온디바이스 한국어 ASR"
 categories:
  - korean_asr

--- a/_posts/Korean_ASR/2026-06-02-wer-over-1-transformer-repetition-outliers.md
+++ b/_posts/Korean_ASR/2026-06-02-wer-over-1-transformer-repetition-outliers.md
@@ -1,4 +1,5 @@
 ---
+lang: ko
 title: "WER이 1.0을 넘을 때 — Transformer ASR의 반복 환각과 outlier 처리"
 categories:
  - korean_asr

--- a/_posts/Korean_ASR/2026-06-02-wer-trap-korean-asr-metrics.md
+++ b/_posts/Korean_ASR/2026-06-02-wer-trap-korean-asr-metrics.md
@@ -1,4 +1,5 @@
 ---
+lang: ko
 title: "한국어 음성 인식에서 WER의 한계와 극복 방법"
 categories:
  - korean_asr

--- a/_posts/Python/2024-09-28-Python 개발 환경.md
+++ b/_posts/Python/2024-09-28-Python 개발 환경.md
@@ -1,4 +1,5 @@
 ---
+lang: ko
 title: "Windows 환경에서 Python 개발 환경 구축"
 categories:
  - python

--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@ sidebar:
     nav: "sidebar-category"
 ---
 
-AI와 음성 인식, 온디바이스 머신러닝을 다루는 기술 블로그입니다.
-논문 리뷰와 한국어 ASR 리더보드 프로젝트 [OpenKoASR](https://gt-kim.github.io/open-korean-automatic-speech-recognition/)의 기록을 정리합니다.
-{: .notice--info}
+Hi, I'm Gwantae — a CS/AI researcher and engineer. This is where I write about
+machine learning, software engineering, research papers, and whatever I happen to be
+building or digging into. Some posts are deep dives, others are short notes.
+
+These days I'm building [OpenKoASR](https://gt-kim.github.io/open-korean-automatic-speech-recognition/),
+an open leaderboard for Korean speech recognition — but you'll find a bit of everything here.


### PR DESCRIPTION
- Home (/) is now the English landing with a broad, English intro; recent-posts list shows English posts (with a friendly empty state linking to /ko/ until English posts exist)
- Top nav: English / 한국어 tabs
- New /ko/ archive listing Korean posts
- Tag posts with `lang` (default en; existing Korean posts set to ko)
- Per-post language switcher (_includes/lang-switch.html) that appears once a counterpart shares the same `ref` key
- Broaden site tagline/description; English copy
- Drop unused jekyll-paginate (avoids mixing languages across pages)