### PR TITLE
Style language tabs as pill buttons; brand author as Starwise

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,8 +19,8 @@ locale                   : "ko_KR"
 title                    : "Starwise Tech Blog"
 title_separator          : "-"
 subtitle                 : "Machine learning, engineering, and everything in between" # site tagline that appears below site title in masthead
-name                     : "GT-KIM"
-description              : "A tech blog by Gwantae Kim on machine learning, software engineering, and research — deep dives, paper notes, and side projects."
+name                     : "Starwise"
+description              : "A tech blog by Starwise on machine learning, software engineering, and research — deep dives, paper notes, and side projects."
 url                      : "https://GT-KIM.github.io" # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
 baseurl                  : # the subpath of your site, e.g. "/blog"
 repository               : "GT-KIM/GT-KIM.github.io" # GitHub username/repo-name e.g. "mmistakes/minimal-mistakes"
@@ -104,7 +104,7 @@ analytics:
 
 # Site Author
 author:
-  name             : "GT-KIM"
+  name             : "Starwise"
   avatar           : "/assets/images/paris_sorbonne.jpg" # path of avatar image, e.g. "/assets/images/bio-photo.jpg"
   bio              : "CS/AI Ph. D."
   location         : "Seoul, South Korea"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,8 +1,8 @@
 # main links
 main:
-  - title: "English"
+  - title: "<i class='fas fa-globe'></i>English"
     url: "/"
-  - title: "한국어"
+  - title: "<i class='fas fa-globe'></i>한국어"
     url: "/ko/"
 
 sidebar-category:

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -21,4 +21,31 @@
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 {% endif %}
 
+<!-- Language tabs (English / 한국어): make them inviting, button-like -->
+<style>
+  .greedy-nav .visible-links .masthead__menu-item a,
+  .greedy-nav .hidden-links .masthead__menu-item a {
+    display: inline-block;
+    margin: 0 .2em;
+    padding: .28em 1.05em;
+    border: 1.5px solid #1e40af;
+    border-radius: 2em;
+    color: #1e40af;
+    font-weight: 700;
+    line-height: 1.5;
+    transition: background-color .18s ease, color .18s ease, transform .12s ease, box-shadow .18s ease;
+  }
+  .greedy-nav .visible-links .masthead__menu-item a:before,
+  .greedy-nav .hidden-links .masthead__menu-item a:before { display: none; }
+  .greedy-nav .masthead__menu-item a i { margin-right: .4em; }
+  .greedy-nav .visible-links .masthead__menu-item a:hover,
+  .greedy-nav .visible-links .masthead__menu-item a:focus,
+  .greedy-nav .hidden-links .masthead__menu-item a:hover {
+    background-color: #1e40af;
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(30, 64, 175, .28);
+  }
+</style>
+
 <!-- end custom head snippets -->

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ header:
       url: "https://gt-kim.github.io/open-korean-automatic-speech-recognition/"
 excerpt: "Machine learning, engineering, and everything in between."
 intro:
-  - excerpt: "Hi, I'm **Gwantae** — a CS/AI researcher and engineer. I write about machine learning, software engineering, research papers, and whatever I'm building or digging into. Some posts are deep dives, others short notes."
+  - excerpt: "Hi, I'm **Starwise** — a CS/AI researcher and engineer. I write about machine learning, software engineering, research papers, and whatever I'm building or digging into. Some posts are deep dives, others short notes."
 feature_row:
   - title: "OpenKoASR — Korean ASR Leaderboard"
     excerpt: "An open, reproducible leaderboard comparing Korean speech-recognition models on one pipeline — same data, same normalization, same metrics."


### PR DESCRIPTION
- Masthead English / 한국어 tabs become rounded pill buttons with a globe icon and a blue fill-on-hover, so they read as inviting language toggles
- Refer to the author as "Starwise" across the blog (site/author name, meta description, home intro); the CV keeps the real name