### PR TITLE
Unify UI across pages with the brand palette

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -46,6 +46,34 @@
     transform: translateY(-1px);
     box-shadow: 0 4px 12px rgba(30, 64, 175, .28);
   }
+
+  /* Per-post language switcher — same pill language as the masthead tabs */
+  .page__lang-switch { margin: 0 0 1.2em; }
+  .page__lang-switch a {
+    display: inline-block;
+    padding: .28em 1.05em;
+    border: 1.5px solid #1e40af;
+    border-radius: 2em;
+    color: #1e40af;
+    font-weight: 600;
+    font-size: .8em;
+    text-decoration: none;
+    transition: background-color .18s ease, color .18s ease, transform .12s ease, box-shadow .18s ease;
+  }
+  .page__lang-switch a i { margin-right: .4em; }
+  .page__lang-switch a:hover {
+    background-color: #1e40af;
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(30, 64, 175, .28);
+  }
+
+  /* Consistent brand accent under titles on content/list pages (not heroes) */
+  #main .page__title,
+  #main .archive__subtitle {
+    border-bottom: 3px solid #1e40af;
+    padding-bottom: .3em;
+  }
 </style>
 
 <!-- end custom head snippets -->

--- a/_includes/lang-switch.html
+++ b/_includes/lang-switch.html
@@ -6,12 +6,8 @@
 {% if page.ref %}
   {% assign mirror = site.posts | where: "ref", page.ref | where_exp: "p", "p.lang != page.lang" | first %}
   {% if mirror %}
-    <p class="page__lang-switch notice--info" style="display:inline-block;padding:.4em .8em;">
-      {% if page.lang == "ko" %}
-        🇺🇸 <a href="{{ mirror.url | relative_url }}">Read this in English</a>
-      {% else %}
-        🇰🇷 <a href="{{ mirror.url | relative_url }}">한국어로 읽기</a>
-      {% endif %}
+    <p class="page__lang-switch">
+      <a href="{{ mirror.url | relative_url }}"><i class="fas fa-globe"></i>{% if page.lang == "ko" %}Read this in English{% else %}한국어로 읽기{% endif %}</a>
     </p>
   {% endif %}
 {% endif %}

--- a/_pages/ko.md
+++ b/_pages/ko.md
@@ -3,6 +3,9 @@ title: "한국어 글"
 layout: archive
 permalink: /ko/
 author_profile: true
+header:
+  overlay_image: /assets/images/hero-starfield.jpg
+  overlay_filter: "rgba(8, 15, 48, 0.45)"
 sidebar:
     nav: "sidebar-category"
 ---

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -5,5 +5,13 @@ search: false
 
 @charset "utf-8";
 
+// ==========================================================================
+// Brand overrides (Starwise) — defined before the skin/main imports so the
+// skin's `!default` values don't win. Gives every page one consistent palette.
+// ==========================================================================
+$primary-color: #1e40af;    // brand blue (matches favicon + hero)
+$link-color: #1e40af;       // hover shade is auto-derived (darker blue) by the theme
+$footer-background-color: #1e40af;
+
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials


### PR DESCRIPTION
- Set theme primary/link/footer colors to brand blue (#1e40af) so links, buttons, TOC, and footer match the hero and favicon on every page
- Give the /ko/ landing the same starfield hero as the English home
- Restyle the per-post language switcher as a pill matching the masthead tabs; drop the broken flag emoji for a Font Awesome globe
- Add a consistent brand underline under content/section titles