### PR TITLE
Fix dangling closing sentence in series introduction

### DIFF
--- a/_posts/ASR_evolution/2026-06-13-asr-series-introduction.md
+++ b/_posts/ASR_evolution/2026-06-13-asr-series-introduction.md
@@ -70,4 +70,4 @@ ASR 문제의 뿌리를 보려면, 먼저 음성인식이 애초에 **어떻게 
 
 ---
 
-*이 글은 [ASR의 진화 시리즈](/asr_evolution/)의 입니다. 전체 목차와 연재 순서는 [로드맵](/asr_evolution/asr-evolution-series-roadmap/)를 참조 바랍니다.*
+*이 글은 [ASR의 진화 시리즈](/asr_evolution/)의 서론입니다. 전체 목차와 연재 순서는 [로드맵](/asr_evolution/asr-evolution-series-roadmap/)을 참조 바랍니다.*


### PR DESCRIPTION
﻿## Summary
Fixes the truncated closing sentence in the series introduction post:
- `...시리즈의 입니다` → `...시리즈의 서론입니다` (completes the dropped word)
- `로드맵를 참조` → `로드맵을 참조` (object particle: 로드맵 takes 을)

One-line change to `_posts/ASR_evolution/2026-06-13-asr-series-introduction.md`.

Stacked on #12 (base: content/asr-series-intro). Merge #12 first; GitHub will retarget this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
